### PR TITLE
Small fix for Three.js revision 61 and above

### DIFF
--- a/threejs-layer.js
+++ b/threejs-layer.js
@@ -97,7 +97,7 @@ ThreejsLayer.prototype.initialize = function(options){
   this.scene = new THREE.Scene();
 
   this.renderer = new THREE.WebGLRenderer({
-    alpha: true;
+    alpha: true,
     clearColor: 0x000000,
     clearAlpha: 0
   });


### PR DESCRIPTION
Recent versions of Three.js (revision 61 and above, tested with r66) requires the alpha to be set to true, otherwise the layer will not become transparent (but black, hiding the Google map).
