### PR TITLE
fix(panning): fix panning issue on certain zoom levels

### DIFF
--- a/threejs-layer.js
+++ b/threejs-layer.js
@@ -174,9 +174,18 @@ ThreejsLayer.prototype.draw = function() {
     bounds.getNorthEast().lat(),
     bounds.getSouthWest().lng()
   );
-
   var projection = this.getProjection();
   var point = projection.fromLatLngToDivPixel(topLeft);
+
+  // If only two partial worlds fit the screen,
+  // show canvas on larger world.
+  var width = projection.getWorldWidth();
+  // Get left position of canvas in the container.
+  var containerLeft = projection.fromLatLngToContainerPixel(topLeft).x;
+  // If left is larger than half of the container size, adjust position.
+  if (containerLeft > this.canvas.width / 2) {
+    point.x = point.x - width;
+  }
 
   this.canvas.style[ThreejsLayer.CSS_TRANSFORM] = 'translate(' +
       Math.round(point.x) + 'px,' +


### PR DESCRIPTION
When only two partial worlds are visible, the WebGL canvas was always rendered on the right one.
Now the WebGL canvas is rendered on the larger world.